### PR TITLE
feat(Step1 / 그린,찌루루): UserInformation 타입 정의

### DIFF
--- a/SignUpFlow/SignUpFlow.xcodeproj/project.pbxproj
+++ b/SignUpFlow/SignUpFlow.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		9A5324492574CF2600AF84A3 /* UserInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A5324482574CF2600AF84A3 /* UserInformation.swift */; };
 		C7352B87256F59BD00C3B7F1 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7352B86256F59BD00C3B7F1 /* AppDelegate.swift */; };
 		C7352B89256F59BD00C3B7F1 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7352B88256F59BD00C3B7F1 /* SceneDelegate.swift */; };
 		C7352B8B256F59BD00C3B7F1 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7352B8A256F59BD00C3B7F1 /* ViewController.swift */; };
@@ -16,6 +17,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		9A5324482574CF2600AF84A3 /* UserInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInformation.swift; sourceTree = "<group>"; };
 		C7352B83256F59BD00C3B7F1 /* SignUpFlow.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SignUpFlow.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7352B86256F59BD00C3B7F1 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C7352B88256F59BD00C3B7F1 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -59,6 +61,7 @@
 				C7352B86256F59BD00C3B7F1 /* AppDelegate.swift */,
 				C7352B88256F59BD00C3B7F1 /* SceneDelegate.swift */,
 				C7352B8A256F59BD00C3B7F1 /* ViewController.swift */,
+				9A5324482574CF2600AF84A3 /* UserInformation.swift */,
 				C7352B8C256F59BD00C3B7F1 /* Main.storyboard */,
 				C7352B8F256F59BF00C3B7F1 /* Assets.xcassets */,
 				C7352B91256F59BF00C3B7F1 /* LaunchScreen.storyboard */,
@@ -138,6 +141,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C7352B8B256F59BD00C3B7F1 /* ViewController.swift in Sources */,
+				9A5324492574CF2600AF84A3 /* UserInformation.swift in Sources */,
 				C7352B87256F59BD00C3B7F1 /* AppDelegate.swift in Sources */,
 				C7352B89256F59BD00C3B7F1 /* SceneDelegate.swift in Sources */,
 			);
@@ -288,6 +292,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = SignUpFlow/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -306,6 +311,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = SignUpFlow/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/SignUpFlow/SignUpFlow/AppDelegate.swift
+++ b/SignUpFlow/SignUpFlow/AppDelegate.swift
@@ -1,9 +1,3 @@
-//
-//  SignUpFlow - AppDelegate.swift
-//  Created by yagom. 
-//  Copyright © yagom academy. All rights reserved.
-// 
-
 import UIKit
 
 @main

--- a/SignUpFlow/SignUpFlow/Base.lproj/Main.storyboard
+++ b/SignUpFlow/SignUpFlow/Base.lproj/Main.storyboard
@@ -1,24 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="SignUpFlow" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
+            <point key="canvasLocation" x="-220" y="138"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/SignUpFlow/SignUpFlow/SceneDelegate.swift
+++ b/SignUpFlow/SignUpFlow/SceneDelegate.swift
@@ -1,9 +1,3 @@
-//
-//  SignUpFlow - SceneDelegate.swift
-//  Created by yagom. 
-//  Copyright © yagom academy. All rights reserved.
-// 
-
 import UIKit
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {

--- a/SignUpFlow/SignUpFlow/UserInformation.swift
+++ b/SignUpFlow/SignUpFlow/UserInformation.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+class UserInformation {
+    let id: String
+    fileprivate(set) var password: String
+    fileprivate(set) var phoneNumber: String
+    fileprivate(set) var dateOfBirth: Date
+    fileprivate(set) var profileImage: String
+    fileprivate(set) var introduction: String
+    
+    static var `default`: UserInformation?
+    
+    init(id: String, password: String, phoneNumber: String, dateOfBirth: Date, profileImage: String, introduction: String) {
+        self.id = id
+        self.password = password
+        self.phoneNumber = phoneNumber
+        self.dateOfBirth = dateOfBirth
+        self.profileImage = profileImage
+        self.introduction = introduction
+    }
+    
+    func isSame(password: String, checkPassword: String) -> Bool {
+        return password == checkPassword
+    }
+    
+    func filterCharacter(phoneNumber: String) -> String {
+        if let _ = Int(phoneNumber) {
+            return phoneNumber
+        } else {
+            return phoneNumber.filter { $0.isNumber }
+        }
+    }
+}
+
+
+

--- a/SignUpFlow/SignUpFlow/ViewController.swift
+++ b/SignUpFlow/SignUpFlow/ViewController.swift
@@ -1,9 +1,3 @@
-//
-//  SignUpFlow - ViewController.swift
-//  Created by yagom. 
-//  Copyright © yagom academy. All rights reserved.
-// 
-
 import UIKit
 
 class ViewController: UIViewController {


### PR DESCRIPTION
Step1 사용자 정보 타입 구현
1. ID는 변경되지 않음으로 let으로 정의
2. 나머지 password / phoneNumber / dateOfBirth / profileImage / introduction 사용자 정보 데이터는 fileprivate(set)으로 정의
3. 이니셜라이저를 통해 초기화
4. 싱글턴 패턴 적용
5. isSame 메서드를 통해 일치하는 패스워드인지 확인
6. filterCharacter 메서드를 통해 전화번호의 숫자 제외한 문자 필터링

[고민점]
-. 2번 구현 항목에서 추후 확장성을 고려하여 fileprivate으로 할지 더 폐쇄적인 private으로 정의할지 고민이됩니다.