### PR TITLE
Step 3: 회원가입 과정1 화면 구현 (찌루루,그린)

### DIFF
--- a/SignUpFlow/SignUpFlow/Base.lproj/Main.storyboard
+++ b/SignUpFlow/SignUpFlow/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="m1E-tc-CMH">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
@@ -43,10 +43,10 @@
                                     <color key="titleColor" systemColor="systemRedColor"/>
                                 </state>
                                 <connections>
-                                    <segue destination="h1C-lT-cQn" kind="show" id="aFI-bi-Z9b"/>
+                                    <segue destination="iSD-rd-Ac3" kind="presentation" id="25L-Ms-G3C"/>
                                 </connections>
                             </button>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="santa" translatesAutoresizingMaskIntoConstraints="NO" id="fpB-qG-4xr">
+                            <imageView clipsSubviews="YES" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="santa" translatesAutoresizingMaskIntoConstraints="NO" id="fpB-qG-4xr">
                                 <rect key="frame" x="66" y="63" width="243" height="243"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="fpB-qG-4xr" secondAttribute="height" multiplier="1:1" id="rA1-8H-2cm"/>
@@ -77,12 +77,12 @@
                     </view>
                     <navigationItem key="navigationItem" id="dG0-fq-mP4"/>
                     <connections>
-                        <outlet property="id" destination="Kug-Gn-Dmd" id="vKx-VY-y9p"/>
+                        <outlet property="idTextField" destination="Kug-Gn-Dmd" id="H9i-J3-Rq9"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="722.39999999999998" y="137.4384236453202"/>
+            <point key="canvasLocation" x="839" y="137"/>
         </scene>
         <!--First Sign Up View Controller-->
         <scene sceneID="lOv-Xt-xFs">
@@ -92,7 +92,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qIp-r1-vXj">
+                            <imageView clipsSubviews="YES" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qIp-r1-vXj">
                                 <rect key="frame" x="16" y="44" width="140" height="140"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" systemColor="opaqueSeparatorColor"/>
@@ -111,13 +111,13 @@
                                 <rect key="frame" x="164" y="97" width="195" height="34"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits" keyboardAppearance="alert" enablesReturnKeyAutomatically="YES" textContentType="new-password"/>
+                                <textInputTraits key="textInputTraits" keyboardAppearance="alert" enablesReturnKeyAutomatically="YES" secureTextEntry="YES" textContentType="new-password"/>
                             </textField>
                             <textField opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Check Password" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="k9K-cv-dfg">
                                 <rect key="frame" x="164" y="150" width="195" height="34"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits" keyboardAppearance="alert" enablesReturnKeyAutomatically="YES" textContentType="new-password"/>
+                                <textInputTraits key="textInputTraits" keyboardAppearance="alert" enablesReturnKeyAutomatically="YES" secureTextEntry="YES" textContentType="new-password"/>
                             </textField>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="XS4-fP-xbQ">
                                 <rect key="frame" x="16" y="192" width="343" height="516"/>
@@ -127,19 +127,23 @@
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences" keyboardAppearance="alert"/>
                             </textView>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Lgc-ue-ZLA">
-                                <rect key="frame" x="199" y="716" width="124" height="62"/>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dIi-pO-3wp">
+                                <rect key="frame" x="235" y="715" width="124" height="62"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="다음"/>
+                                <connections>
+                                    <action selector="storeUserInfo:" destination="h1C-lT-cQn" eventType="touchUpInside" id="ClC-6e-Ws3"/>
+                                    <segue destination="K8D-5c-AVm" kind="show" id="aCL-Uh-yV4"/>
+                                </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="EDC-kX-Wl6">
-                                <rect key="frame" x="24" y="716" width="124" height="62"/>
+                                <rect key="frame" x="16" y="716" width="124" height="62"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="취소">
                                     <color key="titleColor" systemColor="systemRedColor"/>
                                 </state>
                                 <connections>
-                                    <action selector="popToPreviousView" destination="h1C-lT-cQn" eventType="touchUpInside" id="lyf-GF-8iA"/>
+                                    <action selector="cancelSignUp" destination="h1C-lT-cQn" eventType="touchUpInside" id="THL-V1-8rl"/>
                                 </connections>
                             </button>
                         </subviews>
@@ -149,11 +153,12 @@
                     </view>
                     <navigationItem key="navigationItem" id="Nw6-6I-JsI"/>
                     <connections>
-                        <outlet property="checkPasswordField" destination="k9K-cv-dfg" id="YHt-Lg-dsK"/>
-                        <outlet property="idField" destination="3XZ-JT-wSH" id="Eps-My-9Db"/>
-                        <outlet property="passwordField" destination="gLy-2x-39H" id="ODg-DR-qUV"/>
-                        <outlet property="profileImage" destination="qIp-r1-vXj" id="vTy-U4-O2K"/>
-                        <outlet property="textView" destination="XS4-fP-xbQ" id="oW1-F7-gED"/>
+                        <outlet property="checkPasswordTextField" destination="k9K-cv-dfg" id="SS1-rP-wPA"/>
+                        <outlet property="idTextField" destination="3XZ-JT-wSH" id="mnh-JQ-P2B"/>
+                        <outlet property="introductionTextView" destination="XS4-fP-xbQ" id="Xeh-5P-B5P"/>
+                        <outlet property="nextButton" destination="dIi-pO-3wp" id="SW1-AP-5bV"/>
+                        <outlet property="passwordTextField" destination="gLy-2x-39H" id="Gyb-Bn-sRr"/>
+                        <outlet property="profileImageView" destination="qIp-r1-vXj" id="sFr-1j-lTO"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="bzz-h2-hHx" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -163,24 +168,40 @@
                     </connections>
                 </tapGestureRecognizer>
             </objects>
-            <point key="canvasLocation" x="1573.5999999999999" y="136.69950738916256"/>
+            <point key="canvasLocation" x="2292" y="137"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="iDj-F0-z5p">
+            <objects>
+                <viewController id="K8D-5c-AVm" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="GE6-cP-QMT">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="r9j-A8-lqz"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                    <navigationItem key="navigationItem" id="gGq-LP-86p"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="LEQ-Zj-yqT" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="3006" y="137"/>
         </scene>
         <!--Navigation Controller-->
-        <scene sceneID="IYS-Y0-vDy">
+        <scene sceneID="SfR-c7-Wuw">
             <objects>
-                <navigationController automaticallyAdjustsScrollViewInsets="NO" navigationBarHidden="YES" id="m1E-tc-CMH" sceneMemberID="viewController">
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" modalPresentationStyle="fullScreen" navigationBarHidden="YES" id="iSD-rd-Ac3" sceneMemberID="viewController">
                     <toolbarItems/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="Aof-G5-vaa">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="O2x-P0-OJV">
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
                     <connections>
-                        <segue destination="BYZ-38-t0r" kind="relationship" relationship="rootViewController" id="wNn-F0-IAn"/>
+                        <segue destination="h1C-lT-cQn" kind="relationship" relationship="rootViewController" id="nI6-s1-vQa"/>
                     </connections>
                 </navigationController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="VeO-sz-Lhq" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="ZWa-kj-Fa6" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-127" y="137"/>
+            <point key="canvasLocation" x="1573.5999999999999" y="136.69950738916256"/>
         </scene>
     </scenes>
     <resources>

--- a/SignUpFlow/SignUpFlow/Base.lproj/Main.storyboard
+++ b/SignUpFlow/SignUpFlow/Base.lproj/Main.storyboard
@@ -91,14 +91,79 @@
                     <view key="view" contentMode="scaleToFill" id="R8t-xO-CAc">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qIp-r1-vXj">
+                                <rect key="frame" x="16" y="44" width="140" height="140"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <color key="backgroundColor" systemColor="opaqueSeparatorColor"/>
+                                <gestureRecognizers/>
+                                <connections>
+                                    <outletCollection property="gestureRecognizers" destination="B29-TU-jJV" appends="YES" id="Ry1-06-hLF"/>
+                                </connections>
+                            </imageView>
+                            <textField opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="ID" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="3XZ-JT-wSH">
+                                <rect key="frame" x="164" y="44" width="195" height="34"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits" keyboardType="emailAddress" keyboardAppearance="alert" textContentType="email"/>
+                            </textField>
+                            <textField opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Password" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="gLy-2x-39H">
+                                <rect key="frame" x="164" y="97" width="195" height="34"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits" keyboardAppearance="alert" enablesReturnKeyAutomatically="YES" textContentType="new-password"/>
+                            </textField>
+                            <textField opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Check Password" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="k9K-cv-dfg">
+                                <rect key="frame" x="164" y="150" width="195" height="34"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits" keyboardAppearance="alert" enablesReturnKeyAutomatically="YES" textContentType="new-password"/>
+                            </textField>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="XS4-fP-xbQ">
+                                <rect key="frame" x="16" y="192" width="343" height="516"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <color key="backgroundColor" systemColor="opaqueSeparatorColor"/>
+                                <color key="textColor" systemColor="labelColor"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences" keyboardAppearance="alert"/>
+                            </textView>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Lgc-ue-ZLA">
+                                <rect key="frame" x="199" y="716" width="124" height="62"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="다음"/>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="EDC-kX-Wl6">
+                                <rect key="frame" x="24" y="716" width="124" height="62"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="취소">
+                                    <color key="titleColor" systemColor="systemRedColor"/>
+                                </state>
+                                <connections>
+                                    <action selector="popToPreviousView" destination="h1C-lT-cQn" eventType="touchUpInside" id="lyf-GF-8iA"/>
+                                </connections>
+                            </button>
+                        </subviews>
                         <viewLayoutGuide key="safeArea" id="pYo-Ex-t6b"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <gestureRecognizers/>
                     </view>
                     <navigationItem key="navigationItem" id="Nw6-6I-JsI"/>
+                    <connections>
+                        <outlet property="checkPasswordField" destination="k9K-cv-dfg" id="YHt-Lg-dsK"/>
+                        <outlet property="idField" destination="3XZ-JT-wSH" id="Eps-My-9Db"/>
+                        <outlet property="passwordField" destination="gLy-2x-39H" id="ODg-DR-qUV"/>
+                        <outlet property="profileImage" destination="qIp-r1-vXj" id="vTy-U4-O2K"/>
+                        <outlet property="textView" destination="XS4-fP-xbQ" id="oW1-F7-gED"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="bzz-h2-hHx" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+                <tapGestureRecognizer id="B29-TU-jJV">
+                    <connections>
+                        <action selector="editProfileImage:" destination="h1C-lT-cQn" id="AxU-nb-ben"/>
+                    </connections>
+                </tapGestureRecognizer>
             </objects>
-            <point key="canvasLocation" x="1574" y="137"/>
+            <point key="canvasLocation" x="1573.5999999999999" y="136.69950738916256"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="IYS-Y0-vDy">
@@ -120,6 +185,12 @@
     </scenes>
     <resources>
         <image name="santa" width="666.66668701171875" height="666.66668701171875"/>
+        <systemColor name="labelColor">
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="opaqueSeparatorColor">
+            <color red="0.77647058823529413" green="0.77647058823529413" blue="0.78431372549019607" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/SignUpFlow/SignUpFlow/Base.lproj/Main.storyboard
+++ b/SignUpFlow/SignUpFlow/Base.lproj/Main.storyboard
@@ -97,9 +97,6 @@
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" systemColor="opaqueSeparatorColor"/>
                                 <gestureRecognizers/>
-                                <connections>
-                                    <outletCollection property="gestureRecognizers" destination="B29-TU-jJV" appends="YES" id="Ry1-06-hLF"/>
-                                </connections>
                             </imageView>
                             <textField opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="ID" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="3XZ-JT-wSH">
                                 <rect key="frame" x="164" y="44" width="195" height="34"/>
@@ -162,11 +159,6 @@
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="bzz-h2-hHx" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
-                <tapGestureRecognizer id="B29-TU-jJV">
-                    <connections>
-                        <action selector="editProfileImage:" destination="h1C-lT-cQn" id="AxU-nb-ben"/>
-                    </connections>
-                </tapGestureRecognizer>
             </objects>
             <point key="canvasLocation" x="2292" y="137"/>
         </scene>

--- a/SignUpFlow/SignUpFlow/FirstSignUpViewController.swift
+++ b/SignUpFlow/SignUpFlow/FirstSignUpViewController.swift
@@ -7,20 +7,24 @@ final class FirstSignUpViewController: UIViewController {
     @IBOutlet weak var checkPasswordTextField: UITextField!
     @IBOutlet weak var introductionTextView: UITextView!
     @IBOutlet weak var nextButton: UIButton!
-    
+        
     private let imagePicker = UIImagePickerController()
-    
+        
     override func viewDidLoad() {
         super.viewDidLoad()
         nextButton.isEnabled = false
         
+        tapRecognizerSetting()
+    }
+    
+    private func tapRecognizerSetting() {
         let tapRecognizer = UITapGestureRecognizer(target: self, action: #selector(tapView(gestureRecognizer:)))
         self.view.addGestureRecognizer(tapRecognizer)
         
         let profileImageTapRecognizer = UITapGestureRecognizer(target: self, action: #selector(editProfileImage(_:)))
         self.profileImageView.addGestureRecognizer(profileImageTapRecognizer)
     }
-    
+        
     @objc func tapView(gestureRecognizer: UIGestureRecognizer) {
         self.view.endEditing(true)
         
@@ -31,21 +35,28 @@ final class FirstSignUpViewController: UIViewController {
         self.imagePicker.sourceType = .photoLibrary
         self.imagePicker.allowsEditing = true
         self.imagePicker.delegate = self
-
+        
         self.present(self.imagePicker, animated: true)
     }
-
+    
     private func checkInfo() {
-        let checkedPassword: Bool = isSamePassword(password: passwordTextField.text!, checkPassword: checkPasswordTextField.text!)
-        
-        if (idTextField.text?.isEmpty == false) && (passwordTextField.text?.isEmpty == false) && (checkPasswordTextField.text?.isEmpty == false) && (introductionTextView.text.isEmpty == false) && (profileImageView.image != nil) && (checkedPassword == true) {
+        let checkedPassword: Bool = isSamePassword()
+
+        if (idTextField.text?.isEmpty == false) &&
+           (passwordTextField.text?.isEmpty == false) &&
+           (checkPasswordTextField.text?.isEmpty == false) &&
+           (introductionTextView.text.isEmpty == false) &&
+           (profileImageView.image != nil) &&
+           (checkedPassword == true) {
             nextButton.isEnabled = true
         } else {
             nextButton.isEnabled = false
         }
     }
     
-    private func isSamePassword(password: String, checkPassword: String) -> Bool {
+    private func isSamePassword() -> Bool {
+        guard let password = passwordTextField.text, let checkPassword = checkPasswordTextField.text else { return false }
+        
         return password == checkPassword
     }
     
@@ -70,6 +81,7 @@ extension FirstSignUpViewController: UIImagePickerControllerDelegate, UINavigati
         } else if let originalImage = info[.originalImage] as? UIImage {
             resultImage = originalImage
         }
+        
         profileImageView.image = resultImage
         picker.dismiss(animated: true)
         

--- a/SignUpFlow/SignUpFlow/FirstSignUpViewController.swift
+++ b/SignUpFlow/SignUpFlow/FirstSignUpViewController.swift
@@ -1,41 +1,64 @@
 import UIKit
 
 final class FirstSignUpViewController: UIViewController {
-    @IBOutlet weak var profileImage: UIImageView!
-    @IBOutlet weak var idField: UITextField!
-    @IBOutlet weak var passwordField: UITextField!
-    @IBOutlet weak var checkPasswordField: UITextField!
-    @IBOutlet weak var textView: UITextView!
+    @IBOutlet weak var profileImageView: UIImageView!
+    @IBOutlet weak var idTextField: UITextField!
+    @IBOutlet weak var passwordTextField: UITextField!
+    @IBOutlet weak var checkPasswordTextField: UITextField!
+    @IBOutlet weak var introductionTextView: UITextView!
+    @IBOutlet weak var nextButton: UIButton!
     
     private let imagePicker = UIImagePickerController()
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        nextButton.isEnabled = false
         
         let tapRecognizer = UITapGestureRecognizer(target: self, action: #selector(tapView(gestureRecognizer:)))
-        
         self.view.addGestureRecognizer(tapRecognizer)
     }
-        
+    
     @objc func tapView(gestureRecognizer: UIGestureRecognizer) {
         self.view.endEditing(true)
+        
+        checkInfo()
     }
-    
+
     @IBAction func editProfileImage(_ sender: UITapGestureRecognizer) {
         self.imagePicker.sourceType = .photoLibrary
         self.imagePicker.allowsEditing = true
         self.imagePicker.delegate = self
-        
+
         self.present(self.imagePicker, animated: true)
     }
     
-    @IBAction func popToPreviousView() {
-        self.navigationController?.popViewController(animated: true)
+    private func checkInfo() {
+        let checkedPassword: Bool = isSamePassword(password: passwordTextField.text!, checkPassword: checkPasswordTextField.text!)
+        
+        if (idTextField.text?.isEmpty == false) && (passwordTextField.text?.isEmpty == false) && (checkPasswordTextField.text?.isEmpty == false) && (introductionTextView.text.isEmpty == false) && (profileImageView.image != nil) && (checkedPassword == true) {
+            nextButton.isEnabled = true
+        } else {
+            nextButton.isEnabled = false
+        }
+    }
+    
+    private func isSamePassword(password: String, checkPassword: String) -> Bool {
+        return password == checkPassword
+    }
+    
+    @IBAction func storeUserInfo(_ sender: UIButton) {
+        UserInformation.shared.id = idTextField.text
+        UserInformation.shared.password = passwordTextField.text
+        UserInformation.shared.introduction = introductionTextView.text
+        UserInformation.shared.profileImage = profileImageView.image
+    }
+    
+    @IBAction func cancelSignUp() {
+        self.presentingViewController?.dismiss(animated: true, completion: nil)
     }
 }
 
 extension FirstSignUpViewController: UIImagePickerControllerDelegate, UINavigationControllerDelegate {
-     
     func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
         var resultImage: UIImage? = nil
         
@@ -44,9 +67,9 @@ extension FirstSignUpViewController: UIImagePickerControllerDelegate, UINavigati
         } else if let originalImage = info[.originalImage] as? UIImage {
             resultImage = originalImage
         }
-        
-        profileImage.image = resultImage
-        
+        profileImageView.image = resultImage
         picker.dismiss(animated: true)
+        
+        checkInfo()
     }
 }

--- a/SignUpFlow/SignUpFlow/FirstSignUpViewController.swift
+++ b/SignUpFlow/SignUpFlow/FirstSignUpViewController.swift
@@ -18,7 +18,7 @@ final class FirstSignUpViewController: UIViewController {
         self.view.addGestureRecognizer(tapRecognizer)
         
         let profileImageTapRecognizer = UITapGestureRecognizer(target: self, action: #selector(editProfileImage(_:)))
-        self.view.addGestureRecognizer(profileImageTapRecognizer)
+        self.profileImageView.addGestureRecognizer(profileImageTapRecognizer)
     }
     
     @objc func tapView(gestureRecognizer: UIGestureRecognizer) {
@@ -34,7 +34,7 @@ final class FirstSignUpViewController: UIViewController {
 
         self.present(self.imagePicker, animated: true)
     }
-    
+
     private func checkInfo() {
         let checkedPassword: Bool = isSamePassword(password: passwordTextField.text!, checkPassword: checkPasswordTextField.text!)
         

--- a/SignUpFlow/SignUpFlow/FirstSignUpViewController.swift
+++ b/SignUpFlow/SignUpFlow/FirstSignUpViewController.swift
@@ -16,6 +16,9 @@ final class FirstSignUpViewController: UIViewController {
         
         let tapRecognizer = UITapGestureRecognizer(target: self, action: #selector(tapView(gestureRecognizer:)))
         self.view.addGestureRecognizer(tapRecognizer)
+        
+        let profileImageTapRecognizer = UITapGestureRecognizer(target: self, action: #selector(editProfileImage(_:)))
+        self.view.addGestureRecognizer(profileImageTapRecognizer)
     }
     
     @objc func tapView(gestureRecognizer: UIGestureRecognizer) {
@@ -23,8 +26,8 @@ final class FirstSignUpViewController: UIViewController {
         
         checkInfo()
     }
-
-    @IBAction func editProfileImage(_ sender: UITapGestureRecognizer) {
+    
+    @objc func editProfileImage(_ sender: UITapGestureRecognizer) {
         self.imagePicker.sourceType = .photoLibrary
         self.imagePicker.allowsEditing = true
         self.imagePicker.delegate = self

--- a/SignUpFlow/SignUpFlow/FirstSignUpViewController.swift
+++ b/SignUpFlow/SignUpFlow/FirstSignUpViewController.swift
@@ -1,6 +1,52 @@
 import UIKit
 
-class FirstSignUpViewController: UIViewController {
+final class FirstSignUpViewController: UIViewController {
+    @IBOutlet weak var profileImage: UIImageView!
+    @IBOutlet weak var idField: UITextField!
+    @IBOutlet weak var passwordField: UITextField!
+    @IBOutlet weak var checkPasswordField: UITextField!
+    @IBOutlet weak var textView: UITextView!
+    
+    private let imagePicker = UIImagePickerController()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        let tapRecognizer = UITapGestureRecognizer(target: self, action: #selector(tapView(gestureRecognizer:)))
+        
+        self.view.addGestureRecognizer(tapRecognizer)
+    }
+        
+    @objc func tapView(gestureRecognizer: UIGestureRecognizer) {
+        self.view.endEditing(true)
+    }
+    
+    @IBAction func editProfileImage(_ sender: UITapGestureRecognizer) {
+        self.imagePicker.sourceType = .photoLibrary
+        self.imagePicker.allowsEditing = true
+        self.imagePicker.delegate = self
+        
+        self.present(self.imagePicker, animated: true)
+    }
+    
+    @IBAction func popToPreviousView() {
+        self.navigationController?.popViewController(animated: true)
+    }
+}
 
-
+extension FirstSignUpViewController: UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+     
+    func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
+        var resultImage: UIImage? = nil
+        
+        if let editedImage = info[.editedImage] as? UIImage {
+            resultImage = editedImage
+        } else if let originalImage = info[.originalImage] as? UIImage {
+            resultImage = originalImage
+        }
+        
+        profileImage.image = resultImage
+        
+        picker.dismiss(animated: true)
+    }
 }

--- a/SignUpFlow/SignUpFlow/Info.plist
+++ b/SignUpFlow/SignUpFlow/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>test</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>

--- a/SignUpFlow/SignUpFlow/SignInViewController.swift
+++ b/SignUpFlow/SignUpFlow/SignInViewController.swift
@@ -1,13 +1,12 @@
 import UIKit
 
 final class SignInViewController: UIViewController {
-    @IBOutlet weak var id: UITextField!
+    @IBOutlet weak var idTextField: UITextField!
         
     override func viewDidLoad() {
         super.viewDidLoad()
         
         let tapRecognizer = UITapGestureRecognizer(target: self, action: #selector(tapView(gestureRecognizer:)))
-        
         self.view.addGestureRecognizer(tapRecognizer)
     }
         

--- a/SignUpFlow/SignUpFlow/SignInViewController.swift
+++ b/SignUpFlow/SignUpFlow/SignInViewController.swift
@@ -1,9 +1,8 @@
 import UIKit
 
 final class SignInViewController: UIViewController {
-
     @IBOutlet weak var id: UITextField!
-    
+        
     override func viewDidLoad() {
         super.viewDidLoad()
         
@@ -11,7 +10,7 @@ final class SignInViewController: UIViewController {
         
         self.view.addGestureRecognizer(tapRecognizer)
     }
-    
+        
     @objc func tapView(gestureRecognizer: UIGestureRecognizer) {
         self.view.endEditing(true)
     }


### PR DESCRIPTION
[스토리보드]
1. 프로필이미지뷰는 User Interaction Enabled를 체크해줌으로 터치가 될 수 있게 설정
2. 아이디/비밀번호 텍스트 필드는 상황에 맞는 Content Type/Keyboard Type/PlaceHolder 설정
3. '취소' 버튼 클릭 시 로그인 뷰로 넘어가도록 dismiss 구현 (cancelSignUp() 메서드)
4. '다음' 버튼 클릭 시 회원가입 과정2 뷰로 넘어가도록 네비게이션을 통한 이동

[FirstSignUpViewController - 회원가입 과정1]
1. 뷰 로드 시 '다음' 버튼 비활성화 구현
2. tapRecognizerSetting() 메서드 구현으로 뷰 영역 탭 시 키보드가 내려가는 기능과 이미지뷰 탭 시
    imagePicker가 나타나는 기능을 정의
3. checkInfo() 메서드에서는 각 조건이 비어있는지 판별하여 '다음' 버튼을 활성화/비활성화 구현
4. isSamePassword() 메서드에서 입력받은 비밀번호의 일치 여부를 판단하여 Bool 타입으로 리턴
5. storeUserInfo() 메서드를 '다음' 버튼과 액션 연결하여 버튼 클릭 시 싱글턴의 프로퍼티에 각 값이 저장될 수 있도록 구현
6. UIImagePickerControllerDelegate와 UINavigationControllerDelegate 프로토콜의 사용을
    코드의 가독성을 위해 extension으로 빼서 imagePickerController 메서드를 정의하여,
    선택된 이미지를 프로필이미지뷰에 넣어주는 기능을 구현